### PR TITLE
Fix spaces in file names

### DIFF
--- a/run_pylint.py
+++ b/run_pylint.py
@@ -166,13 +166,12 @@ def run_linter(files, args, strict=False):
 
     executable = sys.executable if "python" in sys.executable else "python"
     epylint_part = [executable, "-c", "from pylint import epylint;epylint.Run()"]
-    options = get_options(args, strict=strict)
-    cli_args = epylint_part + files + options
+    cli_args = epylint_part + files + get_options(args, strict=strict)
 
     env = dict(os.environ)
     env["PYTHONPATH"] = os.pathsep.join(sys.path)
 
-    result = subprocess.run(cli_args, capture_output=True, env=env, shell=False)
+    result = subprocess.run(cli_args, capture_output=True, env=env)
     return result.stdout.decode(sys.stdout.encoding)
 
 

--- a/run_pylint.py
+++ b/run_pylint.py
@@ -36,11 +36,9 @@ import datetime
 import argparse
 import platform
 import functools
+import subprocess
 import traceback
 import warnings
-from io import StringIO
-import subprocess
-from subprocess import PIPE, Popen
 
 DESCRIPTION = "Checkstyle script to run pylint on every .py file in the CWD"
 DISABLED_CHECKS = ["missing-docstring",
@@ -171,7 +169,7 @@ def run_linter(files, args, strict=False):
     env = dict(os.environ)
     env["PYTHONPATH"] = os.pathsep.join(sys.path)
 
-    result = subprocess.run(cli_args, capture_output=True, env=env)
+    result = subprocess.run(cli_args, capture_output=True, check=False, env=env)
     return result.stdout.decode(sys.stdout.encoding)
 
 


### PR DESCRIPTION
Possible fix for jazevedo620/cs2340-codestyle#1. Passes files as arguments to a subprocess directly instead of routing through the whole joining/lexing.